### PR TITLE
Fix serialization of task params in Python 3

### DIFF
--- a/ESSArch_Core/WorkflowEngine/serializers.py
+++ b/ESSArch_Core/WorkflowEngine/serializers.py
@@ -107,12 +107,9 @@ class ProcessTaskSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class ProcessTaskDetailSerializer(ProcessTaskSerializer):
-    args = serializers.SerializerMethodField()
+    args = serializers.JSONField()
     params = serializers.SerializerMethodField()
     result = serializers.SerializerMethodField()
-
-    def get_args(self, obj):
-        return obj.args
 
     def get_params(self, obj):
         params = obj.params
@@ -122,7 +119,7 @@ class ProcessTaskDetailSerializer(ProcessTaskSerializer):
             except ProcessTask.DoesNotExist:
                 params[param] = 'waiting on result from %s ...' % task
 
-        return dict((k.encode('utf-8'), v) for k, v in six.iteritems(params))
+        return params
 
     def get_result(self, obj):
         return str(obj.result)


### PR DESCRIPTION
Previously params could include complex objects which were complicated
to serialize. Now we always use simple objects which doesn't require any
special treatment. We instead let DRF and/or Django handle the
serialization.