### PR TITLE
Minor auth fixes

### DIFF
--- a/ESSArch_Core/auth/models.py
+++ b/ESSArch_Core/auth/models.py
@@ -182,7 +182,7 @@ class Group(GroupMixin):
         return self.sub_essauth_group_set
 
     def add_object(self, obj):
-        if getattr(self.group_type, 'codename') != 'organization':
+        if getattr(self, 'group_type') is None or getattr(self.group_type, 'codename') != 'organization':
             raise ValueError('objects cannot be added to non-organization groups')
         return GroupGenericObjects.objects.create(group=self, content_object=obj)
 

--- a/ESSArch_Core/auth/signals.py
+++ b/ESSArch_Core/auth/signals.py
@@ -104,7 +104,7 @@ def notification_post_save(sender, instance, created, **kwargs):
 
 
 @receiver(m2m_changed, sender=User.groups.through)
-def set_default_organization(sender, instance, action, reverse, *args, **kwargs):
+def set_current_organization(sender, instance, action, reverse, *args, **kwargs):
 
     def set_organization(user):
         groups = get_organization_groups(user)


### PR DESCRIPTION
Renaming the signal doesn't affect anything but is a better description of what it does.

If a group doesn't have a type we get an AttributeError when checking the codename. This is fixed by first checking if the `group_type` attribute is `None`.