### PR TITLE
Remove unused IP view method

### DIFF
--- a/ESSArch_Core/ip/views.py
+++ b/ESSArch_Core/ip/views.py
@@ -278,15 +278,3 @@ class InformationPackageViewSet(viewsets.ModelViewSet):
             pip.save()
 
         return Response()
-
-    @detail_route(methods=['put'], url_path='change-profile')
-    def change_profile(self, request, pk=None):
-        ip = self.get_object()
-        new_profile = get_object_or_404(Profile, pk=request.data.get("new_profile"))
-
-        try:
-            ip.change_profile(new_profile)
-        except ValueError as e:
-            raise exceptions.ParseError(e.message)
-
-        return Response({'detail': 'Updating IP (%s) with new profile (%s)' % (ip.pk, new_profile)})


### PR DESCRIPTION
The `change_profile` method in the InformationPackage model was deleted in https://github.com/ESSolutions/ESSArch_Core/commit/35abc3f0d4ccff4d9d311a3f8b3b976ed0914c22