### PR TITLE
Minor Python 3 fixes

### DIFF
--- a/ESSArch_Core/fixity/validation/backends/structure.py
+++ b/ESSArch_Core/fixity/validation/backends/structure.py
@@ -137,8 +137,8 @@ class StructureValidator(BaseValidator):
                     self.validate_folder(os.path.join(filepath, node['name']), node)
 
             passed = True
-        except Exception as e:
-            logger.warning("Structure validation of %s failed, %s" % (filepath, e.message))
+        except Exception:
+            logger.exception(u"Structure validation of {} failed".format(filepath))
             val_obj.message = traceback.format_exc()
             raise
         else:

--- a/ESSArch_Core/search/importers/earderms.py
+++ b/ESSArch_Core/search/importers/earderms.py
@@ -460,7 +460,7 @@ class EardErmsImporter(BaseImporter):
         if len(errands_root):
             with transaction.atomic():
                 with TagStructure.objects.disable_mptt_updates():
-                    tags, tag_versions, tag_reprs, components = itertools.izip(*self.parse_errands(ctsfile, ip, ip.object_path, archive, errands_root[0]))
+                    tags, tag_versions, tag_reprs, components = six.zip(*self.parse_errands(ctsfile, ip, ip.object_path, archive, errands_root[0]))
 
                     Tag.objects.bulk_create(reversed(tags), batch_size=1000)
                     TagVersion.objects.bulk_create(reversed(tag_versions), batch_size=1000)


### PR DESCRIPTION
* `message` attribute no longer exists in `Exception` objects. Use `logger.exception` to log the exception instead
* `itertools.izip` has been replaced with `zip`, use six to be compatible with both