### PR TITLE
Fix appraisal rule-creation API

### DIFF
--- a/ESSArch_Core/maintenance/serializers.py
+++ b/ESSArch_Core/maintenance/serializers.py
@@ -8,9 +8,11 @@ from ESSArch_Core.maintenance.models import (AppraisalJob, AppraisalRule,
 
 class MaintenanceRuleSerializer(serializers.ModelSerializer):
     user = UserSerializer(read_only=True, default=serializers.CurrentUserDefault())
+    public = serializers.BooleanField(default=True)
 
     def validate(self, data):
-        if data['user'].user_profile.current_organization is None and not data['public']:
+        user = self.context['request'].user
+        if user.user_profile.current_organization is None and not data['public']:
             raise serializers.ValidationError("You must be in an organization to create non-public rules")
 
         return data

--- a/ESSArch_Core/maintenance/tests/test_views.py
+++ b/ESSArch_Core/maintenance/tests/test_views.py
@@ -1,0 +1,35 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+class CreateAppraisalRuleTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create(username='user')
+        self.url = reverse('appraisalrule-list')
+
+    def test_unauthenticated(self):
+        response = self.client.post(self.url, {'name': 'foo'})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_authenticated(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(self.url, {'name': 'foo'})
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_authenticated_with_permission(self):
+        perm = Permission.objects.get(codename='add_appraisalrule')
+        self.user.user_permissions.add(perm)
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        response = self.client.post(self.url, {'name': 'foo'})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/ESSArch_Core/testapp/urls.py
+++ b/ESSArch_Core/testapp/urls.py
@@ -2,9 +2,11 @@ from django.conf.urls import include, url
 
 from ESSArch_Core.WorkflowEngine.views import ProcessTaskViewSet, ProcessStepViewSet
 from ESSArch_Core.ip.views import InformationPackageViewSet, WorkareaEntryViewSet
+from ESSArch_Core.maintenance.views import AppraisalRuleViewSet
 from ESSArch_Core.routers import ESSArchRouter
 
 router = ESSArchRouter()
+router.register(r'appraisal-rules', AppraisalRuleViewSet)
 router.register(r'information-packages', InformationPackageViewSet)
 router.register(r'steps', ProcessStepViewSet)
 router.register(r'tasks', ProcessTaskViewSet)


### PR DESCRIPTION
This is a fix for DRF 3.8 which changed how default values are handled for read_only fields. We also ensure that `public` gets a proper default value.