### PR TITLE
Lower amount of tags popped from tag queues each time task is executed

### DIFF
--- a/ESSArch_Core/tasks.py
+++ b/ESSArch_Core/tasks.py
@@ -1071,7 +1071,7 @@ class ProcessTags(DBTask):
         """
         es = get_connection()
         tags = []
-        for i in range(10000):
+        for i in range(100):
             epoch_time = int(time.time())
             # Pop the latest entry, add it to the process queue with the
             # current time as score and return it


### PR DESCRIPTION
Before looking into how to optimize the loop we lower the amount of iterations