### PR TITLE
Lock regex package to 2018.08.29

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -157,6 +157,7 @@ if __name__ == '__main__':
             "opf-fido==1.3.7",
             "pyfakefs==3.4.3",
             "redis==2.10.6",
+            "regex==2018.08.29",
             "requests==2.20.0",
             "requests_toolbelt==0.8.0",
             "retrying==1.3.3",


### PR DESCRIPTION
regex is a dependency of awesome-slugify (dependency of django-groups-manager) which does not have a version of regex specified. This can (and has) lead to an unstable regex version being installed.

Locking it to a specific version gives us more control and stability in how it is used.