### PR TITLE
XML Generator: Add support for creating empty attributes

### DIFF
--- a/ESSArch_Core/essxml/Generator/tests/test_generate.py
+++ b/ESSArch_Core/essxml/Generator/tests/test_generate.py
@@ -198,6 +198,23 @@ class GenerateXMLTestCase(TestCase):
 
         self.assertFalse(os.path.exists(self.fname))
 
+    def test_generate_empty_element_with_empty_attribute_with_allow_empty_on_attribute(self):
+        specification = {
+            '-name': 'foo',
+            '-attr': [
+                {
+                    '-name': 'bar',
+                    '#content': [{'text': ''}],
+                    '-allowEmpty': True,
+                },
+            ]
+        }
+
+        self.generator.generate({self.fname: {'spec': specification}})
+        tree = etree.parse(self.fname)
+        root = tree.getroot()
+        self.assertEqual(len(root.xpath('//foo[@bar=""]')), 1)
+
     def test_generate_multiple_element_same_name_same_level(self):
         specification = {
             '-name': "foo",

--- a/ESSArch_Core/essxml/Generator/xmlGenerator.py
+++ b/ESSArch_Core/essxml/Generator/xmlGenerator.py
@@ -224,9 +224,7 @@ class XMLElement(object):
         if not self.contentIsEmpty(info):
             return False
 
-        any_attribute_with_value = any(value for value in self.el.attrib.values())
-
-        if any_attribute_with_value:
+        if len(self.el.attrib.keys()):
             return False
 
         return True
@@ -318,7 +316,7 @@ class XMLElement(object):
 
             if required and not content:
                 raise ValueError(u"Missing value for required attribute '{}' on element '{}'".format(name, self.get_path()))
-            elif content:
+            elif content or attr.allow_empty:
                 self.el.set(name, content)
 
         if self.external:
@@ -436,6 +434,7 @@ class XMLAttribute(object):
         self.namespace = template.get('-namespace')
         self.required = template.get('-req', False)
         self.content = template.get('#content')
+        self.allow_empty = template.get('-allowEmpty', False)
 
     def parse(self, info, nsmap=None):
         if nsmap is None:
@@ -446,7 +445,11 @@ class XMLAttribute(object):
         if self.namespace:
             name = "{%s}%s" % (nsmap.get(self.namespace), self.name)
 
-        return name, parseContent(self.content, info), self.required
+        content = parseContent(self.content, info)
+        if content is None and self.allow_empty:
+            content = ""
+
+        return name, content, self.required
 
 
 class XMLGenerator(object):


### PR DESCRIPTION
This allows us to create elements like this:

``` xml
<foo bar=""/>
```