### PR TITLE
Use django-redis to get raw client

### DIFF
--- a/ESSArch_Core/search/importers/earderms.py
+++ b/ESSArch_Core/search/importers/earderms.py
@@ -10,8 +10,8 @@ import uuid
 import six
 from django.db import transaction
 from django.db.models import OuterRef, Subquery, F, Q
+from django_redis import get_redis_connection
 from lxml import etree
-from redis import Redis
 from six.moves import cPickle
 
 from ESSArch_Core.search.importers.base import BaseImporter
@@ -21,7 +21,7 @@ from ESSArch_Core.tags.models import Tag, TagStructure, TagVersion
 from ESSArch_Core.util import get_tree_size_and_count, normalize_path, remove_prefix, timestamp_to_datetime
 
 logger = logging.getLogger('essarch.search.importers.EardErmsImporter')
-redis_conn = Redis()
+redis_conn = get_redis_connection()
 
 
 class EardErmsImporter(BaseImporter):

--- a/ESSArch_Core/tags/signals.py
+++ b/ESSArch_Core/tags/signals.py
@@ -3,15 +3,15 @@ import logging
 import six
 from django.db.models.signals import pre_delete, post_delete, post_save
 from django.dispatch import receiver
+from django_redis import get_redis_connection
 from elasticsearch_dsl.connections import get_connection
-from redis import StrictRedis
 from six.moves import cPickle
 
 from ESSArch_Core.tags import DELETION_QUEUE, INDEX_QUEUE, UPDATE_QUEUE
 from ESSArch_Core.tags.models import TagStructure, TagVersion
 
 logger = logging.getLogger('essarch.core')
-r = StrictRedis()
+r = get_redis_connection()
 
 
 @receiver(post_save, sender=TagVersion)

--- a/ESSArch_Core/tasks.py
+++ b/ESSArch_Core/tasks.py
@@ -40,10 +40,10 @@ from django.core.mail import EmailMessage, send_mail
 from django.db import transaction
 from django.db.models import F
 from django.utils import timezone
+from django_redis import get_redis_connection
 from elasticsearch import helpers as es_helpers
 from elasticsearch_dsl.connections import get_connection
 from lxml import etree
-from redis import StrictRedis
 from retrying import retry
 from scandir import walk
 from six.moves import cPickle
@@ -81,7 +81,7 @@ from ESSArch_Core.tags import (DELETION_PROCESS_QUEUE, DELETION_QUEUE,
 from ESSArch_Core.util import convert_file, get_event_element_spec, get_tree_size_and_count
 
 User = get_user_model()
-redis = StrictRedis()
+redis = get_redis_connection()
 
 class GenerateXML(DBTask):
     event_type = 50600


### PR DESCRIPTION
By using django-redis to get the client we ensure that the correct configuration will be used.