### PR TITLE
Allow TapeDrive.io_queue_entry to be blank

### DIFF
--- a/ESSArch_Core/storage/migrations/0006_auto_20170406_2007.py
+++ b/ESSArch_Core/storage/migrations/0006_auto_20170406_2007.py
@@ -50,7 +50,7 @@ class Migration(migrations.Migration):
                 ('device', models.CharField(max_length=255, unique=True)),
                 ('idle_time', models.DurationField(default=timedelta(hours=1))),
                 ('num_of_mounts', models.IntegerField(default=0)),
-                ('io_queue_entry', models.OneToOneField(null=True, on_delete=django.db.models.deletion.PROTECT, related_name='tape_drive', to='storage.IOQueue')),
+                ('io_queue_entry', models.OneToOneField(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, related_name='tape_drive', to='storage.IOQueue')),
                 ('robot', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='tape_drives', to='storage.Robot')),
                 ('last_change', models.DateTimeField(auto_now_add=True, default=django.utils.timezone.now)),
                 ('drive_id', models.IntegerField(default=1)),

--- a/ESSArch_Core/storage/models.py
+++ b/ESSArch_Core/storage/models.py
@@ -597,7 +597,7 @@ class TapeDrive(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     drive_id = models.IntegerField()
     device = models.CharField(max_length=255, unique=True)
-    io_queue_entry = models.OneToOneField('IOQueue', models.PROTECT, related_name='tape_drive', null=True)
+    io_queue_entry = models.OneToOneField('IOQueue', models.PROTECT, related_name='tape_drive', null=True, blank=True)
     num_of_mounts = models.IntegerField(default=0)
     idle_time = models.DurationField(default=timedelta(hours=1))
     last_change = models.DateTimeField(auto_now_add=True)


### PR DESCRIPTION
Fixes the problem with users having to add a IOQueue-entry when creating tape drives using the django admin interface