### PR TITLE
Rename __unicode__ methods to __str__

### DIFF
--- a/ESSArch_Core/WorkflowEngine/models.py
+++ b/ESSArch_Core/WorkflowEngine/models.py
@@ -84,7 +84,7 @@ class Process(models.Model):
     time_created = models.DateTimeField(auto_now_add=True)
     result = PickledObjectField(null=True, default=None, editable=False)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -674,5 +674,5 @@ class ProcessTask(Process):
             ('can_retry', 'Can retry tasks'),
         )
 
-        def __unicode__(self):
+        def __str__(self):
             return '%s - %s' % (self.name, self.id)

--- a/ESSArch_Core/configuration/models.py
+++ b/ESSArch_Core/configuration/models.py
@@ -64,8 +64,7 @@ class Parameter(models.Model):
         ordering = ["entity"]
         verbose_name = 'Parameter'
 
-    def __unicode__(self):
-        # create a unicode representation of this object
+    def __str__(self):
         return self.entity
 
     def get_value_array(self):
@@ -91,7 +90,7 @@ class Path(models.Model):
 
     objects = PathManager()
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s (%s)' % (self.entity, self.value)
 
     class Meta:
@@ -112,8 +111,7 @@ class EventType(models.Model):
         ordering = ["eventType"]
         verbose_name = 'Event Type'
 
-    def __unicode__(self):
-        # create a unicode representation of this object
+    def __str__(self):
         return self.eventDetail
 
     def populate_from_form(self, form):

--- a/ESSArch_Core/ip/models.py
+++ b/ESSArch_Core/ip/models.py
@@ -941,8 +941,7 @@ class EventIP(models.Model):
         ordering = ["eventDateTime", "id"]
         verbose_name = 'Events related to IP'
 
-    def __unicode__(self):
-        # create a unicode representation of this object
+    def __str__(self):
         return '%s (%s)' % (self.eventType.eventDetail, self.id)
 
     def get_value_array(self):

--- a/ESSArch_Core/profiles/models.py
+++ b/ESSArch_Core/profiles/models.py
@@ -272,7 +272,7 @@ class SubmissionAgreement(models.Model):
             ('export_sa', 'Can export SA'),
         )
 
-    def __unicode__(self):
+    def __str__(self):
         # create a unicode representation of this object
         return '%s - %s' % (self.name, self.id)
 
@@ -369,8 +369,7 @@ class Profile(models.Model):
             ('export_profile', 'Can export profile'),
         )
 
-    def __unicode__(self):
-        # create a unicode representation of this object
+    def __str__(self):
         return '%s (%s) - %s' % (self.name, self.profile_type, self.id)
 
     def copy(self, specification_data, new_name, structure=None):


### PR DESCRIPTION
In Python 3 the `__unicode__` method was replaced by the `__str__` method