### PR TITLE
Fix error handling in DeleteFiles on Windows

### DIFF
--- a/ESSArch_Core/tasks.py
+++ b/ESSArch_Core/tasks.py
@@ -615,7 +615,7 @@ class DeleteFiles(DBTask):
                 elif e.errno != 3:
                     raise
 
-            if e.errno == errno.ENOTDIR:
+            elif e.errno == errno.ENOTDIR:
                 os.remove(path)
             elif e.errno != errno.ENOENT:
                 raise


### PR DESCRIPTION
If we are on Windows and the errno is 267, then we don't want to try to delete the file again.