### PR TITLE
Exclude attachment.content when getting tag doc

### DIFF
--- a/ESSArch_Core/tags/models.py
+++ b/ESSArch_Core/tags/models.py
@@ -172,7 +172,7 @@ class TagVersion(models.Model):
     def get_doc(self):
         kwargs = {'params': {}}
         if self.elastic_index == 'document':
-            kwargs['params']['_source_exclude'] = 'data'
+            kwargs['params']['_source_exclude'] = 'attachment.content'
 
         return VersionedDocType.get(index=self.elastic_index, id=str(self.pk), **kwargs)
 


### PR DESCRIPTION
The `data`-field is replaced by `attachment.content` using the pipeline during indexing, therefore only  `attachment.content` has to be excluded