### PR TITLE
Redesign sysinfo page

### DIFF
--- a/ESSArch_Core/configuration/views.py
+++ b/ESSArch_Core/configuration/views.py
@@ -23,7 +23,6 @@
 """
 
 from _version import get_versions
-from ESSArch_Core._version import get_versions as get_core_versions
 import platform
 import socket
 import sys
@@ -39,6 +38,7 @@ except ImportError:  # pip < 10.0
 
 from sqlite3 import sqlite_version
 
+from ESSArch_Core._version import get_versions as get_core_versions
 from ESSArch_Core.configuration.models import (
     Agent,
     ArchivePolicy,

--- a/ESSArch_Core/configuration/views.py
+++ b/ESSArch_Core/configuration/views.py
@@ -98,7 +98,13 @@ class SysInfoView(APIView):
         ]
 
         context['python'] = '.'.join(str(x) for x in sys.version_info[:3])
-        context['platform'] = platform.platform()
+        context['platform'] = {
+            'os': platform.system(),
+            'release': platform.release(),
+            'version': platform.version(),
+            'mac_version': platform.mac_ver(),
+            'win_version': platform.win32_ver(),
+        }
         context['hostname'] = socket.gethostname()
         context['version'] = get_versions()
         context['core_version'] = get_core_versions()

--- a/ESSArch_Core/configuration/views.py
+++ b/ESSArch_Core/configuration/views.py
@@ -23,6 +23,7 @@
 """
 
 from _version import get_versions
+from ESSArch_Core._version import get_versions as get_core_versions
 import platform
 import socket
 import sys
@@ -99,7 +100,8 @@ class SysInfoView(APIView):
         context['python'] = '.'.join(str(x) for x in sys.version_info[:3])
         context['platform'] = platform.platform()
         context['hostname'] = socket.gethostname()
-        context['version'] = get_versions()['version']
+        context['version'] = get_versions()
+        context['core_version'] = get_core_versions()
         context['time_checked'] = timezone.now()
         context['database'] = self.get_database_info()
         context['python_packages'] = pip_freeze()

--- a/ESSArch_Core/frontend/scripts/components/SysInfoComponent.js
+++ b/ESSArch_Core/frontend/scripts/components/SysInfoComponent.js
@@ -1,0 +1,10 @@
+angular.module('essarch.components').component('sysInfoComponent', {
+    templateUrl: 'sys_info_component.html',
+    controller: 'SysInfoComponentCtrl',
+    controllerAs: 'vm',
+    bindings: {
+        icon: '@',
+        name: '@',
+        version: '@'
+    }
+});

--- a/ESSArch_Core/frontend/scripts/controllers/SysInfoComponentCtrl.js
+++ b/ESSArch_Core/frontend/scripts/controllers/SysInfoComponentCtrl.js
@@ -1,0 +1,1 @@
+angular.module('essarch.controllers').controller('SysInfoComponentCtrl', function($scope){});

--- a/ESSArch_Core/frontend/scripts/controllers/VersionCtrl.js
+++ b/ESSArch_Core/frontend/scripts/controllers/VersionCtrl.js
@@ -1,5 +1,16 @@
 angular.module('essarch.controllers').controller('VersionCtrl', function($scope, myService, $window, $state, marked, $anchorScroll, $location, $translate) {
     myService.getVersionInfo().then(function(result) {
+        if (result.platform.os == 'Darwin'){
+            result.platform.os = 'macOS';
+            result.platform.icon = 'fab fa-apple';
+            result.platform.version = result.platform.mac_version[0];
+        } else if (result.platform.os == 'Windows') {
+            result.platform.icon = 'fab fa-windows';
+            result.platform.version = result.platform.win_version[0];
+        } else {
+            result.platform.icon = 'fab fa-linux';
+        }
+
         $scope.sysInfo = result;
     });
     $scope.redirectToEss = function(){

--- a/ESSArch_Core/frontend/scripts/controllers/VersionCtrl.js
+++ b/ESSArch_Core/frontend/scripts/controllers/VersionCtrl.js
@@ -11,6 +11,9 @@ angular.module('essarch.controllers').controller('VersionCtrl', function($scope,
             result.platform.icon = 'fab fa-linux';
         }
 
+        result.python_packages = result.python_packages.map(function(x) {
+            return x.split('==');
+        })
         $scope.sysInfo = result;
     });
     $scope.redirectToEss = function(){
@@ -25,20 +28,17 @@ angular.module('essarch.controllers').controller('VersionCtrl', function($scope,
         $window.open("/docs/"+$translate.use()+"/user_guide/index.html", '_blank');
     }
 
-    $scope.docs = $translate.instant('DOCS');
-    $scope.sysInfo = $translate.instant('SYSTEMINFORMATION');
-    $scope.support = $translate.instant('SUPPORT');
     $scope.tabs = [
         {
-            label: $scope.docs,
+            label: $translate.instant('DOCS'),
             templateUrl: 'static/frontend/views/docs.html'
         },
         {
-            label: $scope.sysInfo,
+            label: $translate.instant('SYSTEMINFORMATION'),
             templateUrl: "sysinfo.html"
         },
         {
-            label: $scope.support,
+            label: $translate.instant('SUPPORT'),
             templateUrl: "static/frontend/views/support.html"
         }
     ];

--- a/ESSArch_Core/frontend/styles/core/modules/sysinfo.scss
+++ b/ESSArch_Core/frontend/styles/core/modules/sysinfo.scss
@@ -1,0 +1,20 @@
+.sys-info-component {
+    flex-grow: 1;
+    flex-basis: 0;
+    margin: 2px;
+    .sys-info-inner {
+        min-width: 150px;
+        border: 1px solid #eaeaea;
+        background-color: #f9f9f9;
+        padding: 7px;
+        .icon {
+            display: table-cell;
+            vertical-align: middle;
+        }
+        .info {
+            display: table-cell;
+            padding-left: 10px;
+            vertical-align: middle;
+        }
+    }
+}

--- a/ESSArch_Core/frontend/styles/core/modules/utils/flex.scss
+++ b/ESSArch_Core/frontend/styles/core/modules/utils/flex.scss
@@ -1,3 +1,8 @@
+.flex-wrap {
+    display: flex;
+    flex-wrap: wrap;
+}
+
 .flex-row {
     display: flex;
     flex-direction: row;

--- a/ESSArch_Core/frontend/styles/core/modules/utils/spacing.scss
+++ b/ESSArch_Core/frontend/styles/core/modules/utils/spacing.scss
@@ -39,6 +39,18 @@
     padding-right: $padding-base-horizontal;
 }
 
+.pl-lg-base {
+    @include large-screen-up {
+        padding-left: $padding-base-horizontal !important;
+    }
+}
+
+.pr-lg-base {
+    @include large-screen-up {
+        padding-right: $padding-base-horizontal !important;
+    }
+}
+
 // Margins
 
 .m-0 {

--- a/ESSArch_Core/frontend/views/sys_info_component.html
+++ b/ESSArch_Core/frontend/views/sys_info_component.html
@@ -1,6 +1,6 @@
-<div style="min-width: 150px; border: 1px solid #eaeaea; background-color: #f9f9f9; padding: 7px;">
-    <i style="display: table-cell; vertical-align: middle;" class="{{vm.icon}} fa-2x"></i>
-    <div style="display: table-cell; padding-left: 10px; vertical-align: middle;">
+<div class="sys-info-inner">
+    <i class="icon fa-2x" ng-class="vm.icon"></i>
+    <div class="info">
         <div>{{vm.name}}</div>
         <div class="white-space-nowrap" style="overflow: hidden;">{{vm.version}}</div>
     </div>

--- a/ESSArch_Core/frontend/views/sys_info_component.html
+++ b/ESSArch_Core/frontend/views/sys_info_component.html
@@ -1,0 +1,7 @@
+<div style="min-width: 150px; border: 1px solid #eaeaea; background-color: #f9f9f9; padding: 7px;">
+    <i style="display: table-cell; vertical-align: middle;" class="{{vm.icon}} fa-2x"></i>
+    <div style="display: table-cell; padding-left: 10px; vertical-align: middle;">
+        <div>{{vm.name}}</div>
+        <div class="white-space-nowrap" style="overflow: hidden;">{{vm.version}}</div>
+    </div>
+</div>

--- a/ESSArch_Core/frontend/views/sysinfo.html
+++ b/ESSArch_Core/frontend/views/sysinfo.html
@@ -1,28 +1,58 @@
-<div class="version-info" ng-if="sysInfo">
-    <p><b>Version:</b> {{sysInfo.version.version}} - {{sysInfo.version.full}}</p>
-    <p><b>ESSArch Core:</b> {{sysInfo.core_version.version}} - {{sysInfo.core_version.full}}</p>
+<div class="version-info pt-base" ng-if="sysInfo">
+    <div class="row m-0">
+        <div class="col-12 col-lg-6 p-0 pr-lg-base">
+            <p><b>Version:</b> {{sysInfo.version.version}} - {{sysInfo.version.full}}</p>
+            <p><b>ESSArch Core:</b> {{sysInfo.core_version.version}} - {{sysInfo.core_version.full}}</p>
 
-    <div class="flex-wrap">
-        <sys-info-component style="flex-grow: 1; flex-basis: 0; margin: 2px;" name="Python" version="{{sysInfo.python}}" icon="fab fa-python"/>
-        <sys-info-component style="flex-grow: 1; flex-basis: 0; margin: 2px;" name="{{sysInfo.platform.os}}" version="{{sysInfo.platform.version}}" icon="{{sysInfo.platform.icon}}"/>
-        <sys-info-component style="flex-grow: 1; flex-basis: 0; margin: 2px;" name="{{sysInfo.database.vendor}}" version="{{sysInfo.database.version}}" icon="fas fa-database"/>
-        <sys-info-component style="flex-grow: 1; flex-basis: 0; margin: 2px;" name="{{'TIME' | translate}}" version="{{sysInfo.time_checked | date: 'yyyy-MM-dd HH:mm'}}" icon="fas fa-clock"/>
+            <div class="flex-wrap">
+                <sys-info-component class="sys-info-component" name="Python" version="{{sysInfo.python}}" icon="fab fa-python"/>
+                <sys-info-component class="sys-info-component" name="{{sysInfo.platform.os}}" version="{{sysInfo.platform.version}}" icon="{{sysInfo.platform.icon}}"/>
+                <sys-info-component class="sys-info-component" name="{{sysInfo.database.vendor}}" version="{{sysInfo.database.version}}" icon="fas fa-database"/>
+                <sys-info-component class="sys-info-component" name="{{'TIME' | translate}}" version="{{sysInfo.time_checked | date: 'yyyy-MM-dd HH:mm'}}" icon="fas fa-clock"/>
+            </div>
+            <p><b>{{'HOSTNAME' | translate}}:</b> {{sysInfo.hostname}}</p>
+            <h4>{{'SETTINGSFLAGS' | translate}}</h4>
+            <table class="table table-striped">
+                <tbody>
+                    <tr ng-repeat="flag in sysInfo.settings_flags" ng-class="{'unexpected': flag.unexpected}">
+                        <td>
+                            {{flag.name}}
+                        </td>
+                        <td>
+                            {{flag.actual.toString().toUpperCase()}}
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="col-12 col-lg-6 p-0 pl-lg-base" style="overflow: hidden;">
+            <p><b>{{'PYTHONPACKAGES' | translate}}: </b></p>
+            <div class="table-container table-x-overflow">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>
+                                {{'PACKAGE' | translate}}
+                            </th>
+                            <th>
+                                {{'VERSION' | translate}}
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr ng-repeat="x in sysInfo.python_packages">
+                            <td>
+                                {{x[0]}}
+                            </td>
+                            <td>
+                                {{x[1]}}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
     </div>
-    <p><b>{{'HOSTNAME' | translate}}:</b> {{sysInfo.hostname}}</p>
-    <h4>{{'SETTINGSFLAGS' | translate}}</h4>
-    <table class="table table-striped">
-        <tbody>
-            <tr ng-repeat="flag in sysInfo.settings_flags" ng-class="{'unexpected': flag.unexpected}">
-                <td>
-                    {{flag.name}}
-                </td>
-                <td>
-                    {{flag.actual.toString().toUpperCase()}}
-                </td>
-            </tr>
-        </tbody>
-    </table>
-    <p><b>{{'PYTHONPACKAGES' | translate}}: </b> {{sysInfo.python_packages.join(' ')}}</p>
 </div>
 <div ng-if="!sysInfo" style="width: 50%;">
     <p>{{'LOADING' | translate}}...</p>

--- a/ESSArch_Core/frontend/views/sysinfo.html
+++ b/ESSArch_Core/frontend/views/sysinfo.html
@@ -1,10 +1,13 @@
-<div class="version-info" style="width: 50%;" ng-if="sysInfo">
+<div class="version-info" ng-if="sysInfo">
     <p><b>Version:</b> {{sysInfo.version.version}} - {{sysInfo.version.full}}</p>
     <p><b>ESSArch Core:</b> {{sysInfo.core_version.version}} - {{sysInfo.core_version.full}}</p>
-    <p><b>Python:</b> {{sysInfo.python}}</p>
-    <p><b>{{'PLATFORM' | translate}}:</b> {{sysInfo.platform}}</p>
-    <p><b>{{'DATABASE' | translate}}: </b> {{sysInfo.database.vendor}} {{sysInfo.database.version}}</p>
-    <p><b>{{'TIME' | translate}}:</b> {{sysInfo.time_checked | date: 'yyyy-MM-dd HH:mm'}}</p>
+
+    <div class="flex-wrap">
+        <sys-info-component style="flex-grow: 1; flex-basis: 0; margin: 2px;" name="Python" version="{{sysInfo.python}}" icon="fab fa-python"/>
+        <sys-info-component style="flex-grow: 1; flex-basis: 0; margin: 2px;" name="{{sysInfo.platform.os}}" version="{{sysInfo.platform.version}}" icon="{{sysInfo.platform.icon}}"/>
+        <sys-info-component style="flex-grow: 1; flex-basis: 0; margin: 2px;" name="{{sysInfo.database.vendor}}" version="{{sysInfo.database.version}}" icon="fas fa-database"/>
+        <sys-info-component style="flex-grow: 1; flex-basis: 0; margin: 2px;" name="{{'TIME' | translate}}" version="{{sysInfo.time_checked | date: 'yyyy-MM-dd HH:mm'}}" icon="fas fa-clock"/>
+    </div>
     <p><b>{{'HOSTNAME' | translate}}:</b> {{sysInfo.hostname}}</p>
     <h4>{{'SETTINGSFLAGS' | translate}}</h4>
     <table class="table table-striped">

--- a/ESSArch_Core/frontend/views/sysinfo.html
+++ b/ESSArch_Core/frontend/views/sysinfo.html
@@ -1,5 +1,5 @@
 <div class="version-info" style="width: 50%;" ng-if="sysInfo">
-    <p><b>Version:</b> v{{sysInfo.version}}</p>
+    <p><b>Version:</b> {{sysInfo.version}}</p>
     <p><b>Python:</b> {{sysInfo.python}}</p>
     <p><b>{{'PLATFORM' | translate}}:</b> {{sysInfo.platform}}</p>
     <p><b>{{'TIME' | translate}}:</b> {{sysInfo.time_checked | date: 'yyyy-MM-dd HH:mm'}}</p>

--- a/ESSArch_Core/frontend/views/sysinfo.html
+++ b/ESSArch_Core/frontend/views/sysinfo.html
@@ -1,5 +1,6 @@
 <div class="version-info" style="width: 50%;" ng-if="sysInfo">
-    <p><b>Version:</b> {{sysInfo.version}}</p>
+    <p><b>Version:</b> {{sysInfo.version.version}} - {{sysInfo.version.full}}</p>
+    <p><b>ESSArch Core:</b> {{sysInfo.core_version.version}} - {{sysInfo.core_version.full}}</p>
     <p><b>Python:</b> {{sysInfo.python}}</p>
     <p><b>{{'PLATFORM' | translate}}:</b> {{sysInfo.platform}}</p>
     <p><b>{{'TIME' | translate}}:</b> {{sysInfo.time_checked | date: 'yyyy-MM-dd HH:mm'}}</p>

--- a/ESSArch_Core/frontend/views/sysinfo.html
+++ b/ESSArch_Core/frontend/views/sysinfo.html
@@ -3,6 +3,7 @@
     <p><b>ESSArch Core:</b> {{sysInfo.core_version.version}} - {{sysInfo.core_version.full}}</p>
     <p><b>Python:</b> {{sysInfo.python}}</p>
     <p><b>{{'PLATFORM' | translate}}:</b> {{sysInfo.platform}}</p>
+    <p><b>{{'DATABASE' | translate}}: </b> {{sysInfo.database.vendor}} {{sysInfo.database.version}}</p>
     <p><b>{{'TIME' | translate}}:</b> {{sysInfo.time_checked | date: 'yyyy-MM-dd HH:mm'}}</p>
     <p><b>{{'HOSTNAME' | translate}}:</b> {{sysInfo.hostname}}</p>
     <h4>{{'SETTINGSFLAGS' | translate}}</h4>
@@ -18,8 +19,6 @@
             </tr>
         </tbody>
     </table>
-    <h4>{{'VERSIONINFORMATION' | translate}}</h4>
-    <p><b>{{'DATABASE' | translate}}: </b> {{sysInfo.database.vendor}} {{sysInfo.database.version}}</p>
     <p><b>{{'PYTHONPACKAGES' | translate}}: </b> {{sysInfo.python_packages.join(' ')}}</p>
 </div>
 <div ng-if="!sysInfo" style="width: 50%;">

--- a/ESSArch_Core/frontend/views/sysinfo.html
+++ b/ESSArch_Core/frontend/views/sysinfo.html
@@ -1,7 +1,7 @@
 <div class="version-info pt-base" ng-if="sysInfo">
     <div class="row m-0">
         <div class="col-12 col-lg-6 p-0 pr-lg-base">
-            <p><b>Version:</b> {{sysInfo.version.version}} - {{sysInfo.version.full}}</p>
+            <p><b>{{'VERSION' | translate}}:</b> {{sysInfo.version.version}} - {{sysInfo.version.full}}</p>
             <p><b>ESSArch Core:</b> {{sysInfo.core_version.version}} - {{sysInfo.core_version.full}}</p>
 
             <div class="flex-wrap">


### PR DESCRIPTION
* Get more specific platform information
* Add icons for Python, OS, database and time information
* List python packages in a table
* Make the page more responsive
* Add ESSArch Core version info