### PR TITLE
Use better data for linux dist and version

### DIFF
--- a/ESSArch_Core/configuration/views.py
+++ b/ESSArch_Core/configuration/views.py
@@ -104,6 +104,7 @@ class SysInfoView(APIView):
             'version': platform.version(),
             'mac_version': platform.mac_ver(),
             'win_version': platform.win32_ver(),
+            'linux_dist': platform.linux_distribution(),
         }
         context['hostname'] = socket.gethostname()
         context['version'] = get_versions()

--- a/ESSArch_Core/frontend/scripts/controllers/VersionCtrl.js
+++ b/ESSArch_Core/frontend/scripts/controllers/VersionCtrl.js
@@ -9,6 +9,8 @@ angular.module('essarch.controllers').controller('VersionCtrl', function($scope,
             result.platform.version = result.platform.win_version[0];
         } else {
             result.platform.icon = 'fab fa-linux';
+            result.platform.os = result.platform.linux_dist[0]
+            result.platform.version = result.platform.linux_dist[1]
         }
 
         result.python_packages = result.python_packages.map(function(x) {


### PR DESCRIPTION
[`platform.linux_distribution`](https://docs.python.org/3.6/library/platform.html#platform.linux_distribution) is deprecated in Python 3.5 and will be removed in 3.8. If we want to keep getting the same data after that we can use the [distro](https://pypi.org/project/distro) package recommended by Python