### PR TITLE
Use built-in scandir

### DIFF
--- a/ESSArch_Core/essxml/Generator/tests/test_generate.py
+++ b/ESSArch_Core/essxml/Generator/tests/test_generate.py
@@ -36,7 +36,7 @@ import six
 from django.test import TestCase
 from django.utils import dateparse, timezone
 from lxml import etree
-from scandir import walk
+from os import walk
 
 from ESSArch_Core.essxml.Generator.xmlGenerator import XMLGenerator, parseContent
 from ESSArch_Core.util import make_unicode, normalize_path

--- a/ESSArch_Core/essxml/Generator/xmlGenerator.py
+++ b/ESSArch_Core/essxml/Generator/xmlGenerator.py
@@ -38,7 +38,7 @@ from natsort import natsorted
 
 from django.utils import timezone
 
-from scandir import walk
+from os import walk
 
 import six
 

--- a/ESSArch_Core/fixity/validation/__init__.py
+++ b/ESSArch_Core/fixity/validation/__init__.py
@@ -5,7 +5,7 @@ import os
 
 from django.conf import settings
 from glob2 import glob
-from scandir import walk
+from os import walk
 
 logger = logging.getLogger('essarch.fixity.validation')
 

--- a/ESSArch_Core/fixity/validation/backends/structure.py
+++ b/ESSArch_Core/fixity/validation/backends/structure.py
@@ -7,7 +7,7 @@ import traceback
 import six
 from django.utils import timezone
 from glob2 import glob, iglob
-from scandir import walk
+from os import walk
 
 from ESSArch_Core.exceptions import ValidationError
 from ESSArch_Core.fixity.models import Validation

--- a/ESSArch_Core/fixity/validation/backends/xml.py
+++ b/ESSArch_Core/fixity/validation/backends/xml.py
@@ -5,7 +5,7 @@ import os
 import six
 from django.utils import timezone
 from lxml import etree, isoschematron
-from scandir import walk
+from os import walk
 
 from ESSArch_Core.essxml.util import find_files, find_pointers, validate_against_schema
 from ESSArch_Core.exceptions import ValidationError

--- a/ESSArch_Core/ip/admin.py
+++ b/ESSArch_Core/ip/admin.py
@@ -28,7 +28,7 @@
 from django.contrib import admin
 import os
 
-from scandir import walk
+from os import walk
 
 # own models ets
 from .models import InformationPackage

--- a/ESSArch_Core/ip/tasks.py
+++ b/ESSArch_Core/ip/tasks.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.utils import timezone
 from lxml import etree
-from scandir import walk
+from os import walk
 
 from ESSArch_Core.WorkflowEngine.dbtask import DBTask
 from ESSArch_Core.configuration.models import ArchivePolicy, Path

--- a/ESSArch_Core/maintenance/models.py
+++ b/ESSArch_Core/maintenance/models.py
@@ -17,7 +17,7 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from glob2 import iglob
 from lxml import etree
-from scandir import walk
+from os import walk
 from weasyprint import HTML
 
 from ESSArch_Core.WorkflowEngine.models import ProcessTask

--- a/ESSArch_Core/maintenance/views.py
+++ b/ESSArch_Core/maintenance/views.py
@@ -9,7 +9,7 @@ from rest_framework.decorators import detail_route
 from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
-from scandir import walk
+from os import walk
 
 from ESSArch_Core.auth.decorators import permission_required_or_403
 from ESSArch_Core.auth.util import get_objects_for_user

--- a/ESSArch_Core/storage/backends/s3.py
+++ b/ESSArch_Core/storage/backends/s3.py
@@ -5,7 +5,7 @@ import os
 import boto3
 import six
 from django.conf import settings
-from scandir import walk
+from os import walk
 
 from ESSArch_Core.storage.backends.base import BaseStorageBackend
 from ESSArch_Core.storage.models import CAS, StorageObject

--- a/ESSArch_Core/storage/copy.py
+++ b/ESSArch_Core/storage/copy.py
@@ -5,7 +5,7 @@ import time
 
 from requests_toolbelt import MultipartEncoder
 from retrying import retry
-from scandir import walk
+from os import walk
 
 from ESSArch_Core.fixity.checksum import calculate_checksum
 

--- a/ESSArch_Core/tasks.py
+++ b/ESSArch_Core/tasks.py
@@ -45,7 +45,7 @@ from elasticsearch import helpers as es_helpers
 from elasticsearch_dsl.connections import get_connection
 from lxml import etree
 from retrying import retry
-from scandir import walk
+from os import walk
 from six.moves import cPickle
 
 from ESSArch_Core.WorkflowEngine.dbtask import DBTask

--- a/ESSArch_Core/util.py
+++ b/ESSArch_Core/util.py
@@ -52,7 +52,7 @@ from datetime import datetime
 from lxml import etree
 from natsort import natsorted
 
-from scandir import scandir, walk
+from os import scandir, walk
 
 from subprocess import Popen, PIPE
 

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,6 @@ if __name__ == '__main__':
             "requests==2.20.0",
             "requests_toolbelt==0.8.0",
             "retrying==1.3.3",
-            "scandir==1.9.0",
             "six==1.10.0",
             "weasyprint==43",
         ],


### PR DESCRIPTION
`scandir` is built-in to Python since 3.5: https://docs.python.org/3/whatsnew/3.5.html#pep-471-os-scandir-function-a-better-and-faster-directory-iterator