### PR TITLE
Use built-in mock

### DIFF
--- a/ESSArch_Core/WorkflowEngine/tests/test_tasks.py
+++ b/ESSArch_Core/WorkflowEngine/tests/test_tasks.py
@@ -25,7 +25,7 @@
 import os
 import shutil
 
-import unittest.mock
+from unittest import mock
 from celery import states as celery_states
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings

--- a/ESSArch_Core/WorkflowEngine/tests/test_tasks.py
+++ b/ESSArch_Core/WorkflowEngine/tests/test_tasks.py
@@ -25,7 +25,7 @@
 import os
 import shutil
 
-import mock
+import unittest.mock
 from celery import states as celery_states
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings

--- a/ESSArch_Core/essxml/Generator/tests/test_generate.py
+++ b/ESSArch_Core/essxml/Generator/tests/test_generate.py
@@ -31,7 +31,7 @@ import tempfile
 import unittest
 from collections import OrderedDict
 
-import mock
+import unittest.mock
 import six
 from django.test import TestCase
 from django.utils import dateparse, timezone

--- a/ESSArch_Core/essxml/Generator/tests/test_generate.py
+++ b/ESSArch_Core/essxml/Generator/tests/test_generate.py
@@ -31,7 +31,7 @@ import tempfile
 import unittest
 from collections import OrderedDict
 
-import unittest.mock
+from unittest import mock
 import six
 from django.test import TestCase
 from django.utils import dateparse, timezone

--- a/ESSArch_Core/essxml/tests/test_util.py
+++ b/ESSArch_Core/essxml/tests/test_util.py
@@ -26,7 +26,7 @@ import os
 import shutil
 import tempfile
 
-import unittest.mock
+from unittest import mock
 import six
 from django.test import TestCase
 from lxml import etree

--- a/ESSArch_Core/essxml/tests/test_util.py
+++ b/ESSArch_Core/essxml/tests/test_util.py
@@ -26,7 +26,7 @@ import os
 import shutil
 import tempfile
 
-import mock
+import unittest.mock
 import six
 from django.test import TestCase
 from lxml import etree

--- a/ESSArch_Core/fixity/receipt/tests.py
+++ b/ESSArch_Core/fixity/receipt/tests.py
@@ -1,4 +1,4 @@
-import mock
+import unittest.mock
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 

--- a/ESSArch_Core/fixity/receipt/tests.py
+++ b/ESSArch_Core/fixity/receipt/tests.py
@@ -1,4 +1,4 @@
-import unittest.mock
+from unittest import mock
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 

--- a/ESSArch_Core/fixity/test_format.py
+++ b/ESSArch_Core/fixity/test_format.py
@@ -1,4 +1,4 @@
-import mock
+import unittest.mock
 from django.test import TestCase
 
 from ESSArch_Core.configuration.models import Path

--- a/ESSArch_Core/fixity/test_format.py
+++ b/ESSArch_Core/fixity/test_format.py
@@ -1,4 +1,4 @@
-import unittest.mock
+from unittest import mock
 from django.test import TestCase
 
 from ESSArch_Core.configuration.models import Path

--- a/ESSArch_Core/ip/tests/test_models.py
+++ b/ESSArch_Core/ip/tests/test_models.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import tempfile
 
-import unittest.mock
+from unittest import mock
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 

--- a/ESSArch_Core/ip/tests/test_models.py
+++ b/ESSArch_Core/ip/tests/test_models.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import tempfile
 
-import mock
+import unittest.mock
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 

--- a/ESSArch_Core/storage/tests.py
+++ b/ESSArch_Core/storage/tests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import errno
-import mock
+import unittest.mock
 import uuid
 
 from django.test import TestCase

--- a/ESSArch_Core/storage/tests.py
+++ b/ESSArch_Core/storage/tests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import errno
-import unittest.mock
+from unittest import mock
 import uuid
 
 from django.test import TestCase

--- a/ESSArch_Core/test_util.py
+++ b/ESSArch_Core/test_util.py
@@ -1,6 +1,6 @@
 from subprocess import PIPE
 
-import mock
+import unittest.mock
 from django.test import TestCase
 
 from ESSArch_Core.util import convert_file

--- a/ESSArch_Core/test_util.py
+++ b/ESSArch_Core/test_util.py
@@ -1,6 +1,6 @@
 from subprocess import PIPE
 
-import unittest.mock
+from unittest import mock
 from django.test import TestCase
 
 from ESSArch_Core.util import convert_file

--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,6 @@ if __name__ == '__main__':
             "httpretty==0.9.5",
             "jsonpickle==1.0",
             "lxml==4.2.5",
-            "mock==2.0.0",
             "natsort==5.4.1",
             "opf-fido==1.3.7",
             "pyfakefs==3.4.3",


### PR DESCRIPTION
`mock` is built-in to Python since 3.3: https://docs.python.org/3/whatsnew/3.3.html