### PR TITLE
Use language of responsible user when running tasks

### DIFF
--- a/ESSArch_Core/WorkflowEngine/dbtask.py
+++ b/ESSArch_Core/WorkflowEngine/dbtask.py
@@ -45,7 +45,7 @@ from django.db import (
     OperationalError,
     transaction,
 )
-from django.utils import timezone
+from django.utils import timezone, translation
 
 from ESSArch_Core.essxml.Generator.xmlGenerator import parseContent
 from ESSArch_Core.ip.models import EventIP, InformationPackage
@@ -151,7 +151,15 @@ class DBTask(Task):
                 time_started=timezone.now()
             )
 
-        return self._run(*args, **kwargs)
+        try:
+            user = User.objects.get(pk=self.responsible)
+            if user.user_profile is not None:
+                with translation.override(user.user_profile.language):
+                    return self._run(*args, **kwargs)
+            else:
+                return self._run(*args, **kwargs)
+        except User.DoesNotExist:
+            return self._run(*args, **kwargs)
 
     def _run(self, *args, **kwargs):
         lock = None

--- a/ESSArch_Core/WorkflowEngine/tests/test_tasks.py
+++ b/ESSArch_Core/WorkflowEngine/tests/test_tasks.py
@@ -155,8 +155,7 @@ class test_undoing_tasks(TestCase):
         task.refresh_from_db()
         self.assertEqual(task.status, celery_states.SUCCESS)
 
-        with self.assertNumQueries(5):
-            res = task.undo()
+        res = task.undo()
         task.refresh_from_db()
         self.assertEqual(res.get(), x-y)
 


### PR DESCRIPTION
When a user is set as responsible for a task we use [`translation.override`](https://docs.djangoproject.com/en/1.11/ref/utils/#django.utils.translation.override) to temporarily set the language used in the task to generate the correct language for different messages and values, e.g. notifications sent to the user when a task completes.