### PR TITLE
Upgrade django-groups-manager to 0.6.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ if __name__ == '__main__':
             "django==1.11.16",
             "django-cors-headers==2.4.0",
             "django-filter==2.0",
-            "django-groups-manager==0.6.0",
+            "django-groups-manager==0.6.2",
             "django-guardian==1.4.9",
             "django-jsonfield==1.0.1",
             "django-mptt==0.9.1",


### PR DESCRIPTION
Prepares us for Django 2 and enables more i18n customisation