### PR TITLE
Upgrade opf-fido to 1.3.12

### DIFF
--- a/ESSArch_Core/fixity/format.py
+++ b/ESSArch_Core/fixity/format.py
@@ -16,6 +16,11 @@ logger = logging.getLogger('essarch.fixity.format')
 
 DEFAULT_MIMETYPE = 'application/octet-stream'
 
+FORMAT_FILES = [
+    'formats-v94.xml',
+    'format_extensions.xml'
+]
+
 
 class FormatIdentifier:
     _fido = None
@@ -27,7 +32,7 @@ class FormatIdentifier:
     def fido(self):
         if self._fido is None:
             logger.debug('Initiating fido')
-            self._fido = Fido(handle_matches=self.handle_matches)
+            self._fido = Fido(handle_matches=self.handle_matches, format_files=FORMAT_FILES)
             logger.info('Initiated fido')
         return self._fido
 

--- a/setup.py
+++ b/setup.py
@@ -175,7 +175,7 @@ if __name__ == '__main__':
             "jsonpickle==1.0",
             "lxml==4.2.5",
             "natsort==5.4.1",
-            "opf-fido==1.3.7",
+            "opf-fido==1.3.12",
             "pyfakefs==3.4.3",
             "pywin32==224;platform_system=='Windows'",
             "redis==2.10.6",
@@ -183,7 +183,7 @@ if __name__ == '__main__':
             "requests==2.20.0",
             "requests_toolbelt==0.8.0",
             "retrying==1.3.3",
-            "six==1.10.0",
+            "six==1.11.0",
             "weasyprint==43",
         ],
         extras_require={


### PR DESCRIPTION
By specifying the format files to fido we can use version 1.3.12 even though it is broken.
The upgrade to 1.3.12, among other things, adds the following features  

 * allows us to bump up six which avoids some version conflicts
 * greatly increases the performance for determining formats of some TIFF-files