### PR TITLE
Remove Python 2/3 compatibility imports

### DIFF
--- a/ESSArch_Core/WorkflowEngine/dbtask.py
+++ b/ESSArch_Core/WorkflowEngine/dbtask.py
@@ -22,8 +22,6 @@
     Email - essarch@essolutions.se
 """
 
-from __future__ import absolute_import, division, unicode_literals
-
 import logging
 import time
 

--- a/ESSArch_Core/WorkflowEngine/models.py
+++ b/ESSArch_Core/WorkflowEngine/models.py
@@ -22,8 +22,6 @@
     Email - essarch@essolutions.se
 """
 
-from __future__ import unicode_literals
-
 import importlib
 import itertools
 import logging

--- a/ESSArch_Core/WorkflowEngine/tests/tasks.py
+++ b/ESSArch_Core/WorkflowEngine/tests/tasks.py
@@ -22,8 +22,6 @@
     Email - essarch@essolutions.se
 """
 
-from __future__ import absolute_import
-
 from ESSArch_Core.ip.models import InformationPackage
 from ESSArch_Core.WorkflowEngine.dbtask import DBTask
 

--- a/ESSArch_Core/auth/models.py
+++ b/ESSArch_Core/auth/models.py
@@ -27,7 +27,6 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group as DjangoGroup, Permission
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
-from django.utils.encoding import python_2_unicode_compatible
 from django.db import models, transaction
 from django.utils.translation import ugettext_lazy as _
 from groups_manager import exceptions_gm
@@ -48,7 +47,6 @@ class GroupGenericObjects(models.Model):
         unique_together = ['group', 'object_id', 'content_type']
 
 
-@python_2_unicode_compatible
 class GroupMemberRole(GroupMemberRoleMixin):
     codename = models.CharField(_('codename'), unique=True, max_length=255)
     label = models.SlugField(_('label'), blank=True, max_length=255)

--- a/ESSArch_Core/configuration/models.py
+++ b/ESSArch_Core/configuration/models.py
@@ -25,7 +25,6 @@
 from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 import uuid
@@ -153,7 +152,6 @@ class DefaultColumnVisible(models.Model):
     visible = models.BooleanField(default=True)
 
 
-@python_2_unicode_compatible
 class ArchivePolicy(models.Model):
     """Specifies how an IP should be archived"""
 

--- a/ESSArch_Core/essxml/util.py
+++ b/ESSArch_Core/essxml/util.py
@@ -22,8 +22,6 @@
     Email - essarch@essolutions.se
 """
 
-from __future__ import absolute_import
-
 import os
 import uuid
 

--- a/ESSArch_Core/fixity/checksum.py
+++ b/ESSArch_Core/fixity/checksum.py
@@ -1,5 +1,3 @@
-from __future__ import division, unicode_literals
-
 import hashlib
 import logging
 import os

--- a/ESSArch_Core/fixity/format.py
+++ b/ESSArch_Core/fixity/format.py
@@ -1,5 +1,3 @@
-from __future__ import division, unicode_literals
-
 import logging
 import mimetypes
 import os

--- a/ESSArch_Core/fixity/validation/backends/checksum.py
+++ b/ESSArch_Core/fixity/validation/backends/checksum.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 import traceback
 

--- a/ESSArch_Core/fixity/validation/backends/format.py
+++ b/ESSArch_Core/fixity/validation/backends/format.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 import traceback
 

--- a/ESSArch_Core/fixity/validation/backends/mediaconch.py
+++ b/ESSArch_Core/fixity/validation/backends/mediaconch.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import errno
 import logging
 import os

--- a/ESSArch_Core/fixity/validation/backends/structure.py
+++ b/ESSArch_Core/fixity/validation/backends/structure.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 import os
 import traceback

--- a/ESSArch_Core/fixity/validation/backends/verapdf.py
+++ b/ESSArch_Core/fixity/validation/backends/verapdf.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import errno
 import logging
 import os

--- a/ESSArch_Core/fixity/validation/tests.py
+++ b/ESSArch_Core/fixity/validation/tests.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import errno
 import hashlib
 import os

--- a/ESSArch_Core/ip/models.py
+++ b/ESSArch_Core/ip/models.py
@@ -22,8 +22,6 @@
     Email - essarch@essolutions.se
 """
 
-from __future__ import division
-
 import errno
 import io
 import logging
@@ -43,7 +41,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.db import models, transaction
 from django.db.models import Count, Max, Min
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 from lxml import etree
@@ -155,7 +152,6 @@ class InformationPackageManager(models.Manager):
         return self.for_user(user, 'view_informationpackage')
 
 
-@python_2_unicode_compatible
 class InformationPackage(models.Model):
     """
     Informaion Package

--- a/ESSArch_Core/profiles/models.py
+++ b/ESSArch_Core/profiles/models.py
@@ -28,7 +28,6 @@ from copy import copy
 import jsonfield
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from ESSArch_Core.profiles.utils import fill_specification_data, profile_types
@@ -69,7 +68,6 @@ class ProfileQuerySet(models.query.QuerySet):
         return profile_set.first().profile
 
 
-@python_2_unicode_compatible
 class ProfileSA(models.Model):
     id = models.UUIDField(
         primary_key=True, default=uuid.uuid4, editable=False
@@ -94,7 +92,6 @@ class ProfileSA(models.Model):
         )
 
 
-@python_2_unicode_compatible
 class ProfileIP(models.Model):
     id = models.UUIDField(
         primary_key=True, default=uuid.uuid4, editable=False

--- a/ESSArch_Core/storage/models.py
+++ b/ESSArch_Core/storage/models.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import errno
 import os
 import uuid
@@ -11,7 +9,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import Case, When, Value, IntegerField
 from django.db.models.functions import Cast
-from django.utils.encoding import python_2_unicode_compatible
 from picklefield.fields import PickledObjectField
 from retrying import retry
 
@@ -157,7 +154,6 @@ class StorageMethodQueryset(models.QuerySet):
         return self.filter(containers=True)
 
 
-@python_2_unicode_compatible
 class StorageMethod(models.Model):
     """Disk, tape or CAS"""
 
@@ -192,7 +188,6 @@ class StorageMethod(models.Model):
         return str(self.id)
 
 
-@python_2_unicode_compatible
 class StorageMethodTargetRelation(models.Model):
     """Relation between StorageMethod and StorageTarget"""
 
@@ -251,7 +246,6 @@ class StorageTargetQueryset(models.QuerySet):
         ).order_by('remote', 'container_order', 'storage_type')
 
 
-@python_2_unicode_compatible
 class StorageTarget(models.Model):
     """A series of tapes or a single disk"""
 
@@ -356,7 +350,6 @@ class StorageMediumQueryset(models.QuerySet):
         ).order_by('remote', 'container_order', 'storage_type')
 
 
-@python_2_unicode_compatible
 class StorageMedium(models.Model):
     "A single storage medium (device)"
 
@@ -473,7 +466,6 @@ class StorageObjectQueryset(models.QuerySet):
         ).order_by('remote', 'container_order', 'storage_type')
 
 
-@python_2_unicode_compatible
 class StorageObject(models.Model):
     """The stored representation of an archive object on a storage medium"""
 
@@ -613,7 +605,6 @@ class StorageObject(models.Model):
         return False
 
 
-@python_2_unicode_compatible
 class TapeDrive(models.Model):
     STATUS_CHOICES = (
         (0, 'Inactive'),
@@ -636,7 +627,6 @@ class TapeDrive(models.Model):
         return self.device
 
 
-@python_2_unicode_compatible
 class TapeSlot(models.Model):
     STATUS_CHOICES = (
         (0, 'Inactive'),
@@ -664,7 +654,6 @@ class TapeSlot(models.Model):
         return str(self.slot_id)
 
 
-@python_2_unicode_compatible
 class Robot(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     label = models.CharField("Describing label for the robot", max_length=255, blank=True)

--- a/ESSArch_Core/util.py
+++ b/ESSArch_Core/util.py
@@ -22,8 +22,6 @@
     Email - essarch@essolutions.se
 """
 
-from __future__ import absolute_import
-
 import errno
 import glob
 import io


### PR DESCRIPTION
We have upgraded to Python 3, we no longer require tools that makes the migration easier