### PR TITLE
Fix bug when getting earliest/latest appraisal job

### DIFF
--- a/ESSArch_Core/maintenance/models.py
+++ b/ESSArch_Core/maintenance/models.py
@@ -147,7 +147,7 @@ class AppraisalJob(MaintenanceJob):
 
     MAINTENANCE_TYPE = 'appraisal'
 
-    class Meta:
+    class Meta(MaintenanceJob.Meta):
         permissions = (
             ('run_appraisaljob', 'Can run appraisal job'),
         )


### PR DESCRIPTION
AppraisalJob had a `Meta` class that didn't inherit from `MaintenanceJob.Meta` which meant that `get_latest_by` wasn't set. This led to `.earliest` and `.latest` not working for appraisal jobs