### PR TITLE
Replace detail/list_routes with action decorator

### DIFF
--- a/ESSArch_Core/WorkflowEngine/views.py
+++ b/ESSArch_Core/WorkflowEngine/views.py
@@ -32,7 +32,7 @@ from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
 
 from rest_framework import exceptions
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import action
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.response import Response
@@ -104,7 +104,7 @@ class ProcessStepViewSet(viewsets.ModelViewSet):
 
         return ProcessStepDetailSerializer
 
-    @detail_route(methods=['get'], url_path='child-steps')
+    @action(detail=True, methods=['get'], url_path='child-steps')
     def child_steps(self, request, pk=None):
         step = self.get_object()
         child_steps = step.child_steps.all()
@@ -141,7 +141,7 @@ class ProcessTaskViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
         return ProcessTaskDetailSerializer
 
     @transaction.atomic
-    @detail_route(methods=['post'], permission_classes=[CanRetry])
+    @action(detail=True, methods=['post'], permission_classes=[CanRetry])
     def retry(self, request, pk=None):
         obj = self.get_object()
         if obj.status != celery_states.FAILURE:
@@ -157,7 +157,7 @@ class ProcessTaskViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
         return Response({'status': 'retries task'})
 
     @transaction.atomic
-    @detail_route(methods=['post'], permission_classes=[CanUndo])
+    @action(detail=True, methods=['post'], permission_classes=[CanUndo])
     def undo(self, request, pk=None):
         self.get_object().undo()
         return Response({'status': 'undoing task'})

--- a/ESSArch_Core/auth/views.py
+++ b/ESSArch_Core/auth/views.py
@@ -52,7 +52,7 @@ from rest_auth.views import (
 )
 
 from rest_framework import permissions, status, viewsets
-from rest_framework.decorators import api_view, permission_classes, list_route
+from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.generics import RetrieveUpdateAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -136,7 +136,7 @@ class NotificationViewSet(viewsets.ModelViewSet):
 
         return NotificationSerializer
 
-    @list_route(methods=['post'], url_path='set-all-seen')
+    @action(detail=False, methods=['post'], url_path='set-all-seen')
     def set_all_seen(self, request):
         self.get_queryset().update(seen=True)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/ESSArch_Core/ip/views.py
+++ b/ESSArch_Core/ip/views.py
@@ -3,7 +3,7 @@ import itertools
 from django.db.models import Prefetch
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import exceptions, filters, mixins, status, viewsets
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.response import Response
@@ -67,7 +67,7 @@ class WorkareaEntryViewSet(mixins.DestroyModelMixin, viewsets.ReadOnlyModelViewS
 
         return qs
 
-    @detail_route(methods=['post'], url_path='validate')
+    @action(detail=True, methods=['post'], url_path='validate')
     def validate(self, request, pk=None):
         workarea = self.get_object()
         ip = workarea.ip
@@ -110,7 +110,7 @@ class WorkareaEntryViewSet(mixins.DestroyModelMixin, viewsets.ReadOnlyModelViewS
         task.run()
         return Response("Validating IP")
 
-    @detail_route(methods=['post'], url_path='transform')
+    @action(detail=True, methods=['post'], url_path='transform')
     def transform(self, request, pk=None):
         workarea = self.get_object()
         ip = workarea.ip
@@ -250,7 +250,7 @@ class InformationPackageViewSet(viewsets.ModelViewSet):
         ).select_related('submission_agreement')
         return queryset
 
-    @detail_route(methods=['post'], url_path='change-organization')
+    @action(detail=True, methods=['post'], url_path='change-organization')
     def change_organization(self, request, pk=None):
         ip = self.get_object()
 
@@ -261,7 +261,7 @@ class InformationPackageViewSet(viewsets.ModelViewSet):
         ip.change_organization(org)
         return Response()
 
-    @detail_route()
+    @action(detail=True)
     def workflow(self, request, pk=None):
         ip = self.get_object()
         hidden = request.query_params.get('hidden')
@@ -279,7 +279,7 @@ class InformationPackageViewSet(viewsets.ModelViewSet):
         serializer.is_valid()
         return Response(serializer.data)
 
-    @detail_route(methods=['put'], url_path='check-profile')
+    @action(detail=True, methods=['put'], url_path='check-profile')
     def check_profile(self, request, pk=None):
         ip = self.get_object()
         ptype = request.data.get("type")

--- a/ESSArch_Core/maintenance/views.py
+++ b/ESSArch_Core/maintenance/views.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
 from glob2 import iglob
 from rest_framework import filters, status, viewsets
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import action
 from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
@@ -52,7 +52,7 @@ class MaintenanceJobViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     filterset_class = MaintenanceJobFilter
     filter_backends = (filters.OrderingFilter, DjangoFilterBackend)
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def run(self, request, pk=None):
         job = self.get_object()
         job.start_date = timezone.now()
@@ -60,7 +60,7 @@ class MaintenanceJobViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
         job.run()
         return Response(status=status.HTTP_202_ACCEPTED)
 
-    @detail_route(methods=['get'])
+    @action(detail=True, methods=['get'])
     def report(self, request, pk=None):
         path = self.get_object()._get_report_directory()
         path = os.path.join(path, pk + '.pdf')
@@ -79,11 +79,11 @@ class AppraisalJobViewSet(MaintenanceJobViewSet):
     filterset_class = AppraisalJobFilter
 
     @permission_required_or_403(['maintenance.run_appraisaljob'])
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def run(self, request, pk=None):
         return super().run(request, pk)
 
-    @detail_route(methods=['get'])
+    @action(detail=True, methods=['get'])
     def preview(self, request, pk=None):
         job = self.get_object()
         ips = job.rule.information_packages.filter(appraisal_date__lte=timezone.now(), active=True)
@@ -124,7 +124,7 @@ class ConversionJobViewSet(MaintenanceJobViewSet):
     serializer_class = ConversionJobSerializer
     filterset_class = ConversionJobFilter
 
-    @detail_route(methods=['get'])
+    @action(detail=True, methods=['get'])
     def preview(self, request, pk=None):
         job = self.get_object()
         ips = job.rule.information_packages.all()

--- a/ESSArch_Core/profiles/views.py
+++ b/ESSArch_Core/profiles/views.py
@@ -3,7 +3,7 @@ from django.db.models import Max, Prefetch
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework_extensions.mixins import NestedViewSetMixin
 from rest_framework import exceptions, viewsets
-from rest_framework.decorators import detail_route, list_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.permissions import DjangoModelPermissions, SAFE_METHODS
 
@@ -30,7 +30,7 @@ class SubmissionAgreementViewSet(viewsets.ModelViewSet):
     filter_backends = (DjangoFilterBackend,)
     filterset_fields = ('published',)
 
-    @detail_route()
+    @action(detail=True)
     def profiles(self, request, pk=None):
         sa = self.get_object()
         profiles = [p for p in sa.get_profiles() if p is not None]
@@ -107,7 +107,7 @@ class ProfileIPDataViewSet(viewsets.ModelViewSet):
         return super().update(request, *args, **kwargs)
 
     @transaction.atomic
-    @list_route(methods=['post'], url_path='import-from-template')
+    @action(detail=False, methods=['post'], url_path='import-from-template')
     def import_from_template(self, request):
         relation = request.data.get('relation')
         relation = ProfileIP.objects.get(pk=relation)
@@ -118,7 +118,7 @@ class ProfileIPDataViewSet(viewsets.ModelViewSet):
                                                       version=max_version + 1)
         return Response(ProfileIPDataSerializer(profile_ip_obj).data)
 
-    @detail_route(methods=['post'], url_path='save-as-template')
+    @action(detail=True, methods=['post'], url_path='save-as-template')
     def save_as_template(self, request, pk=None):
         obj = self.get_object()
         name = request.data.get('name')


### PR DESCRIPTION
`detail_route` and `list_route` were deprecated and replaced by the `action` decorator in Django Rest Framework 3.8. Release notes: https://www.django-rest-framework.org/community/3.8-announcement/#action-decorator-replaces-list_route-and-detail_route