### PR TITLE
Revert "Disabel patch status on codecov (#226)"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,4 +4,3 @@ coverage:
       default: off
       backend:
         flags: backend
-    patch: off


### PR DESCRIPTION
This reverts commit 8b99265e93a47c5616c9b094a70155983766ca78 which didn't seem to have any effect