### PR TITLE
Upgrade Django Filter to 2.1.0

### DIFF
--- a/ESSArch_Core/filters.py
+++ b/ESSArch_Core/filters.py
@@ -26,7 +26,7 @@ import django_filters
 from django_filters import rest_framework as filters
 from django_filters.constants import EMPTY_VALUES
 
-from ESSArch_Core.forms.fields import IsoDateTimeRangeField, MultipleTextField
+from ESSArch_Core.forms.fields import MultipleTextField
 
 
 def string_to_bool(s):
@@ -39,10 +39,6 @@ def string_to_bool(s):
         'true': True,
         'false': False,
     }.get(s.lower(), None)
-
-
-class IsoDateTimeFromToRangeFilter(filters.DateTimeFromToRangeFilter):
-    field_class = IsoDateTimeRangeField
 
 
 class MultipleCharFilter(filters.MultipleChoiceFilter):

--- a/ESSArch_Core/forms/fields.py
+++ b/ESSArch_Core/forms/fields.py
@@ -1,16 +1,6 @@
 from django import forms
-from django_filters.fields import IsoDateTimeField, RangeField
-from django_filters.widgets import DateRangeWidget
 
 from ESSArch_Core.forms.widgets import MultipleTextWidget
-
-
-class IsoDateTimeRangeField(RangeField):
-    widget = DateRangeWidget
-
-    def __init__(self, *args, **kwargs):
-        fields = (IsoDateTimeField(), IsoDateTimeField())
-        super().__init__(fields, *args, **kwargs)
 
 
 class MultipleTextField(forms.Field):

--- a/ESSArch_Core/ip/filters.py
+++ b/ESSArch_Core/ip/filters.py
@@ -3,7 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 from django_filters import rest_framework as filters
 from rest_framework import exceptions
 
-from ESSArch_Core.filters import IsoDateTimeFromToRangeFilter, ListFilter, MultipleCharFilter
+from ESSArch_Core.filters import ListFilter, MultipleCharFilter
 from ESSArch_Core.ip.models import Agent, EventIP, InformationPackage, Workarea
 
 User = get_user_model()
@@ -43,10 +43,10 @@ class InformationPackageFilter(filters.FilterSet):
     )
     state = MultipleCharFilter()
     object_size = filters.RangeFilter()
-    start_date = IsoDateTimeFromToRangeFilter()
-    end_date = IsoDateTimeFromToRangeFilter()
-    create_date = IsoDateTimeFromToRangeFilter()
-    entry_date = IsoDateTimeFromToRangeFilter()
+    start_date = filters.IsoDateTimeFromToRangeFilter()
+    end_date = filters.IsoDateTimeFromToRangeFilter()
+    create_date = filters.IsoDateTimeFromToRangeFilter()
+    entry_date = filters.IsoDateTimeFromToRangeFilter()
     package_type = MultipleCharFilter()
     package_type_name_exclude = filters.CharFilter(
         label=_("Excluded Package Type"),
@@ -67,7 +67,7 @@ class InformationPackageFilter(filters.FilterSet):
 
 
 class EventIPFilter(filters.FilterSet):
-    eventDateTime = IsoDateTimeFromToRangeFilter()
+    eventDateTime = filters.IsoDateTimeFromToRangeFilter()
 
     class Meta:
         model = EventIP

--- a/ESSArch_Core/tests/test_filters.py
+++ b/ESSArch_Core/tests/test_filters.py
@@ -1,37 +1,8 @@
-import datetime
-
-from django.utils import timezone
 from django.test import TestCase
 from django_filters import rest_framework as filters
 
-from ESSArch_Core.filters import IsoDateTimeFromToRangeFilter, ListFilter
+from ESSArch_Core.filters import ListFilter
 from ESSArch_Core.ip.models import InformationPackage
-
-
-class IsoDateTimeFromToRangeFilterTests(TestCase):
-    def test_filtering(self):
-        tz = timezone.get_current_timezone()
-        InformationPackage.objects.create(
-            entry_date=datetime.datetime(2016, 1, 1, 10, 0, tzinfo=tz))
-        InformationPackage.objects.create(
-            entry_date=datetime.datetime(2016, 1, 2, 12, 45, tzinfo=tz))
-        InformationPackage.objects.create(
-            entry_date=datetime.datetime(2016, 1, 3, 18, 15, tzinfo=tz))
-        InformationPackage.objects.create(
-            entry_date=datetime.datetime(2016, 1, 3, 19, 30, tzinfo=tz))
-
-        class F(filters.FilterSet):
-            entry_date = IsoDateTimeFromToRangeFilter()
-
-            class Meta:
-                model = InformationPackage
-                fields = ['entry_date']
-
-        results = F(data={
-            'entry_date_after': '2016-01-02T10:00:00.000',
-            'entry_date_before': '2016-01-03T19:00:00.000'
-        })
-        self.assertEqual(len(results.qs), 2)
 
 
 class ListFilterTests(TestCase):

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ if __name__ == '__main__':
             "dj-database-url==0.5.0",
             "django==1.11.20",
             "django-cors-headers==2.4.0",
-            "django-filter==2.0",
+            "django-filter==2.1.0",
             "django-groups-manager==0.6.2",
             "django-guardian==1.4.9",
             "django-mptt==0.9.1",


### PR DESCRIPTION
[2.1.0](https://github.com/carltongibson/django-filter/releases/tag/2.1.0) now includes `IsoDateTimeFromToRangeFilter` which means that we can delete our copy