### PR TITLE
/api/sysinfo should work even when services are down.

### DIFF
--- a/ESSArch_Core/WorkflowEngine/__init__.py
+++ b/ESSArch_Core/WorkflowEngine/__init__.py
@@ -23,9 +23,19 @@
 """
 
 import celery
+import logging
 
 default_app_config = 'ESSArch_Core.WorkflowEngine.apps.WorkflowEngineConfig'
+logger = logging.getLogger('essarch.workflowengine')
 
 
-def get_workers():
-    return celery.current_app.control.inspect().stats()
+def get_workers(rabbitmq):
+    if rabbitmq.get('error'):
+        logger.error("RabbitMQ seems down. Wont get stats of celery workers.")
+        return None
+
+    try:
+        return celery.current_app.control.inspect().stats()
+    except Exception:
+        logger.exception("Error when checking stats of celery workers.")
+        return None

--- a/ESSArch_Core/configuration/views.py
+++ b/ESSArch_Core/configuration/views.py
@@ -104,10 +104,10 @@ def get_redis_info(full=False):
             return props
         return {'version': props['redis_version']}
     except RedisError:
-        logger.exception("Redis seems to be down.")
+        logger.exception("Could not connect to Redis.")
         return {
             'version': 'unknown',
-            'error': 'ERROR on redis. Check the logs for more detail.'
+            'error': 'Error connecting to Redis. Check the logs for more detail.'
         }
 
 
@@ -138,7 +138,7 @@ class SysInfoView(APIView):
     """
 
     def get(self, request):
-        full = str_2_bool_convert(request.query_params.get('full', False))
+        full = string_to_bool(request.query_params.get('full', 'false'))
         context = {}
 
         # Flags in settings: Their expected  and actual values.

--- a/ESSArch_Core/configuration/views.py
+++ b/ESSArch_Core/configuration/views.py
@@ -36,6 +36,8 @@ from django_redis import get_redis_connection
 from redis.exceptions import RedisError
 from elasticsearch_dsl.connections import get_connection as get_es_connection
 
+from ESSArch_Core.filters import string_to_bool
+
 try:
     from pip._internal.operations.freeze import freeze as pip_freeze
 except ImportError:  # pip < 10.0
@@ -123,13 +125,6 @@ def get_rabbitmq_info(full=False):
             'version': 'unknown',
             'error': 'Error connecting to RabbitMQ. Check the logs for more detail.'
         }
-
-
-def str_2_bool_convert(s):
-    if isinstance(s, str):
-        return s.lower() == 'true'
-    if isinstance(s, bool):
-        return s
 
 
 class SysInfoView(APIView):

--- a/ESSArch_Core/frontend/views/sysinfo.html
+++ b/ESSArch_Core/frontend/views/sysinfo.html
@@ -30,7 +30,7 @@
           icon="fas fa-clock"
         />
         <sys-info-component class="sys-info-component" name="RabbitMQ" version="{{sysInfo.rabbitmq.version}}" />
-        <sys-info-component class="sys-info-component" name="Redis" version="{{sysInfo.redis.redis_version}}" />
+        <sys-info-component class="sys-info-component" name="Redis" version="{{sysInfo.redis.version}}" />
         <sys-info-component
           ng-if="sysInfo.elasticsearch"
           class="sys-info-component"


### PR DESCRIPTION
- Add error handling for RabbitMQ
- Add error handling for Redis
- Add error handling for celery workers

- Also add support for fetching only version or full detailed info from RabbitMQ and Redis services.
