### PR TITLE
Fix how events are fetched from IP

### DIFF
--- a/ESSArch_Core/tasks_util.py
+++ b/ESSArch_Core/tasks_util.py
@@ -210,8 +210,8 @@ def validate_files(ip, responsible, rootdir, validate_fileformat, validate_integ
 
 def append_events(ip, events, filename):
     if not filename:
-        ip = InformationPackage.objects.get(pk=ip)
-        filename = os.path.join(ip.object_path, ip.get_events_file_path())
+        ip_obj = InformationPackage.objects.get(pk=ip)
+        filename = os.path.join(ip_obj.object_path, ip_obj.get_events_file_path())
     generator = XMLGenerator(filepath=filename)
     template = get_event_element_spec()
 


### PR DESCRIPTION
When filterng EventIP objects with IP it expects the primary key of the IP, not an IP object. 